### PR TITLE
Fix DOM init for Node compatibility

### DIFF
--- a/script.js
+++ b/script.js
@@ -124,14 +124,16 @@ function $(id) {
 }
 
 // ページロード時の初期化
-document.addEventListener('DOMContentLoaded', () => {
-    initializeApp();
-});
+if (typeof document !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', () => {
+        initializeApp();
+    });
+}
 
 // アプリケーションの初期化
 function initializeApp() {
     // ダークモード設定の読み込み
-    const savedTheme = localStorage.getItem('theme') || 'light';
+    const savedTheme = (typeof localStorage !== 'undefined' && localStorage.getItem('theme')) || 'light';
     if (savedTheme === 'dark') {
         document.documentElement.setAttribute('data-theme', 'dark');
         document.getElementById('themeSwitch').checked = true;
@@ -142,10 +144,14 @@ function initializeApp() {
         document.getElementById('themeSwitch').addEventListener('change', function(e) {
             if (e.target.checked) {
                 document.documentElement.setAttribute('data-theme', 'dark');
-                localStorage.setItem('theme', 'dark');
+                if (typeof localStorage !== 'undefined') {
+                    localStorage.setItem('theme', 'dark');
+                }
             } else {
                 document.documentElement.setAttribute('data-theme', 'light');
-                localStorage.setItem('theme', 'light');
+                if (typeof localStorage !== 'undefined') {
+                    localStorage.setItem('theme', 'light');
+                }
             }
         });
     }


### PR DESCRIPTION
## Summary
- add guards for DOM initialization
- prevent localStorage access in non-browser environments

## Testing
- `npm test`
- `node script.js`

------
https://chatgpt.com/codex/tasks/task_e_684072e4dec48325a4774f94cc903e0e