### PR TITLE
Fix collapsing for skill categories

### DIFF
--- a/script.js
+++ b/script.js
@@ -305,7 +305,19 @@ function initAccordions() {
             toggleAccordion('investigateSkillsContent', this);
         });
     }
-    
+
+    if (document.getElementById('actionSkillsHeader')) {
+        document.getElementById('actionSkillsHeader').addEventListener('click', function() {
+            toggleAccordion('actionSkillsContent', this);
+        });
+    }
+
+    if (document.getElementById('negotiationSkillsHeader')) {
+        document.getElementById('negotiationSkillsHeader').addEventListener('click', function() {
+            toggleAccordion('negotiationSkillsContent', this);
+        });
+    }
+
     if (document.getElementById('knowledgeSkillsHeader')) {
         document.getElementById('knowledgeSkillsHeader').addEventListener('click', function() {
             toggleAccordion('knowledgeSkillsContent', this);
@@ -327,6 +339,12 @@ function initAccordions() {
     }
     if (document.getElementById('investigateSkillsContent')) {
         document.getElementById('investigateSkillsContent').style.display = 'block';
+    }
+    if (document.getElementById('actionSkillsContent')) {
+        document.getElementById('actionSkillsContent').style.display = 'block';
+    }
+    if (document.getElementById('negotiationSkillsContent')) {
+        document.getElementById('negotiationSkillsContent').style.display = 'block';
     }
     if (document.getElementById('knowledgeSkillsContent')) {
         document.getElementById('knowledgeSkillsContent').style.display = 'block';


### PR DESCRIPTION
## Summary
- allow action and negotiation skill sections to collapse

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684078a857ec8325beb0a8bd0599abab