### PR TITLE
Fix skill initialization

### DIFF
--- a/script.js
+++ b/script.js
@@ -497,12 +497,14 @@ function initializeCharacteristicFields() {
 function initializeSkillFields() {
     // 各技能フィールドを取得
     for (const skill in defaultSkills) {
+        // すべての技能をキャラクターデータにセット
+        character.skills[skill] = defaultSkills[skill];
+
         const element = $(skill);
         if (element) {
             // 初期値を設定
             element.value = defaultSkills[skill];
-            character.skills[skill] = defaultSkills[skill];
-            
+
             // イベントリスナーを追加
             element.addEventListener('input', () => {
                 updateSkill(skill);


### PR DESCRIPTION
## Summary
- populate `character.skills` with default values before checking for input fields

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68407c6f97248325b6ee50fd6e6d29dd