### PR TITLE
Add preview entries for all skills

### DIFF
--- a/index.html
+++ b/index.html
@@ -1545,7 +1545,79 @@
                                     <div class="skill-value" id="preview-ownLanguage"></div>
                                 </div>
                             </div>
-                            
+
+                            <div class="skills-column">
+                                <h4>行動技能</h4>
+                                <div class="skill-preview-item">
+                                    <div class="skill-name">登攀：</div>
+                                    <div class="skill-value" id="preview-climb"></div>
+                                </div>
+                                <div class="skill-preview-item">
+                                    <div class="skill-name">跳躍：</div>
+                                    <div class="skill-value" id="preview-jump"></div>
+                                </div>
+                                <div class="skill-preview-item">
+                                    <div class="skill-name">水泳：</div>
+                                    <div class="skill-value" id="preview-swim"></div>
+                                </div>
+                                <div class="skill-preview-item">
+                                    <div class="skill-name">運転：</div>
+                                    <div class="skill-value" id="preview-drive"></div>
+                                </div>
+                                <div class="skill-preview-item">
+                                    <div class="skill-name">運転(その他)：</div>
+                                    <div class="skill-value" id="preview-driveOther"></div>
+                                </div>
+                                <div class="skill-preview-item">
+                                    <div class="skill-name">操縦1：</div>
+                                    <div class="skill-value" id="preview-pilot1"></div>
+                                </div>
+                                <div class="skill-preview-item">
+                                    <div class="skill-name">操縦2：</div>
+                                    <div class="skill-value" id="preview-pilot2"></div>
+                                </div>
+                                <div class="skill-preview-item">
+                                    <div class="skill-name">乗馬：</div>
+                                    <div class="skill-value" id="preview-ride"></div>
+                                </div>
+                                <div class="skill-preview-item">
+                                    <div class="skill-name">重機械操作：</div>
+                                    <div class="skill-value" id="preview-operateHeavyMachinery"></div>
+                                </div>
+                                <div class="skill-preview-item">
+                                    <div class="skill-name">機械修理：</div>
+                                    <div class="skill-value" id="preview-mechanicalRepair"></div>
+                                </div>
+                                <div class="skill-preview-item">
+                                    <div class="skill-name">電気修理：</div>
+                                    <div class="skill-value" id="preview-electricalRepair"></div>
+                                </div>
+                            </div>
+
+                            <div class="skills-column">
+                                <h4>交渉技能</h4>
+                                <div class="skill-preview-item">
+                                    <div class="skill-name">言いくるめ：</div>
+                                    <div class="skill-value" id="preview-fastTalk"></div>
+                                </div>
+                                <div class="skill-preview-item">
+                                    <div class="skill-name">説得：</div>
+                                    <div class="skill-value" id="preview-persuade"></div>
+                                </div>
+                                <div class="skill-preview-item">
+                                    <div class="skill-name">値切り：</div>
+                                    <div class="skill-value" id="preview-bargain"></div>
+                                </div>
+                                <div class="skill-preview-item">
+                                    <div class="skill-name">信用：</div>
+                                    <div class="skill-value" id="preview-creditRating"></div>
+                                </div>
+                                <div class="skill-preview-item">
+                                    <div class="skill-name">変装：</div>
+                                    <div class="skill-value" id="preview-disguise"></div>
+                                </div>
+                            </div>
+
                             <div class="skills-column">
                                 <h4>戦闘技能</h4>
                                 <div class="skill-preview-item">

--- a/styles.css
+++ b/styles.css
@@ -872,7 +872,7 @@ input:checked + .slider .slider-icon-moon {
 
 @media (min-width: 768px) {
     .skills-grid {
-        grid-template-columns: repeat(3, 1fr);
+        grid-template-columns: repeat(5, 1fr);
     }
 }
 


### PR DESCRIPTION
## Summary
- show Action and Negotiation skills in the preview tab
- expand the skills grid layout for five columns

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407cda89a48325b209dd342c3c78e9