### PR TITLE
Allow .txt import

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
                 </select>
                 <button id="exportBtn" class="btn info"><i class="fas fa-file-export"></i> エクスポート</button>
                 <button id="importBtn" class="btn info"><i class="fas fa-file-import"></i> インポート</button>
-                <input type="file" id="importFile" accept=".json" style="display: none;">
+                <input type="file" id="importFile" accept=".json,.txt" style="display: none;">
                 <button id="printBtn" class="btn accent"><i class="fas fa-print"></i> 印刷</button>
                 <button id="generatePdfBtn" class="btn danger"><i class="fas fa-file-pdf"></i> PDF生成</button>
             </div>


### PR DESCRIPTION
## Summary
- allow `importFile` input to accept text files
- support `.txt` extension in importCharacter()
- parse iacharacter-style text files via new `parseIaCharacterText`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684280eb38b48325b6dc75c681acedb6