### PR TITLE
Fix skill mapping for law and pharmacy

### DIFF
--- a/script.js
+++ b/script.js
@@ -1406,7 +1406,8 @@ function parseIaCharacterText(text) {
         '天文学': 'astronomy',
         '博物学': 'naturalHistory',
         '物理学': 'physics',
-        '法律': 'pharmacy',
+        '法律': 'law',
+        '薬学': 'pharmacy',
         '歴史': 'history'
     };
 


### PR DESCRIPTION
## Summary
- correct mapping for 法律 to `law` and add 薬学 -> `pharmacy`
- verified that parsing a sample text correctly sets these values

## Testing
- `npm install`
- `npm test`
- `node script.js` via vm to parse sample text

------
https://chatgpt.com/codex/tasks/task_e_684299ed0a048325bf6430652bdebb6f