### PR TITLE
Fix infinite recursion in updateSkillTotal

### DIFF
--- a/script.js
+++ b/script.js
@@ -2043,10 +2043,6 @@ function updateSkillTotal(skillId) {
         $(skillId).value = total;
     }
     
-    // 回避技能の場合、DEXから計算される初期値を反映
-    if (skillId === 'dodge') {
-        updateDodgeBaseValue();
-    }
 }
 
 // 回避技能の初期値更新（DEXの2倍）


### PR DESCRIPTION
## Summary
- fix recursion caused by `updateSkillTotal('dodge')` calling `updateDodgeBaseValue`
- update test snapshots

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68429a5207348325ae5fc0cea3d36ca7